### PR TITLE
feat: Datenanalyse-Features – Preisperioden, CSV-Export, Foto-Lightbox, Jahresvergleich

### DIFF
--- a/src/app/auswertungen/page.tsx
+++ b/src/app/auswertungen/page.tsx
@@ -6,11 +6,13 @@ import { useAuthenticationStatus } from '@nhost/nextjs';
 import { useRouter } from 'next/navigation';
 import { format, subMonths, startOfYear, startOfMonth } from 'date-fns';
 import { de } from 'date-fns/locale';
-import { BarChart3, Table2, Loader2, Euro, Gauge } from 'lucide-react';
+import { BarChart3, Table2, Loader2, Euro, Gauge, Download, ArrowLeftRight } from 'lucide-react';
 import {
   ResponsiveContainer,
   AreaChart,
   Area,
+  LineChart,
+  Line,
   XAxis,
   YAxis,
   Tooltip,
@@ -50,6 +52,7 @@ export default function AuswertungenPage() {
   const [viewMode, setViewMode] = useState<ViewMode>('chart');
   const [dataMode, setDataMode] = useState<DataMode>('verbrauch');
   const [zeitraumIdx, setZeitraumIdx] = useState(2);
+  const [jahresvergleich, setJahresvergleich] = useState(false);
   const [selectedTypen, setSelectedTypen] = useState<string[]>([]);
   const [selectedStellen, setSelectedStellen] = useState<Record<string, string[]>>({});
 
@@ -75,12 +78,16 @@ export default function AuswertungenPage() {
     });
   }, [verbrauchstypen]);
 
-  const von = zeitraumIdx === CUSTOM_IDX
-    ? customVon
-    : zeitraumIdx === 3
-      ? format(startOfYear(now), 'yyyy-MM-dd')
-      : format(subMonths(now, ZEITRAEUME[zeitraumIdx].months), 'yyyy-MM-dd');
-  const bis = zeitraumIdx === CUSTOM_IDX ? customBis : format(now, 'yyyy-MM-dd');
+  const currentYear = now.getFullYear();
+
+  const von = jahresvergleich
+    ? `${currentYear - 1}-01-01`
+    : zeitraumIdx === CUSTOM_IDX
+      ? customVon
+      : zeitraumIdx === 3
+        ? format(startOfYear(now), 'yyyy-MM-dd')
+        : format(subMonths(now, ZEITRAEUME[zeitraumIdx].months), 'yyyy-MM-dd');
+  const bis = zeitraumIdx === CUSTOM_IDX && !jahresvergleich ? customBis : format(now, 'yyyy-MM-dd');
 
   const activeTypen = selectedTypen.length > 0 ? selectedTypen : verbrauchstypen.map((t) => t.id);
 
@@ -106,6 +113,7 @@ export default function AuswertungenPage() {
     : allWerte;
 
   const chartData = buildChartData(filteredWerte, verbrauchstypen, dataMode, vertraege);
+  const jvData = jahresvergleich ? buildJahresvergleichData(filteredWerte, verbrauchstypen, activeTypen, dataMode, vertraege, currentYear) : [];
 
   const toggleTyp = (id: string) => {
     setSelectedTypen((prev) =>
@@ -144,6 +152,20 @@ export default function AuswertungenPage() {
           </div>
           <div className="flex items-center gap-2">
             <button
+              onClick={() => setJahresvergleich(j => !j)}
+              className={`ht-btn-ghost text-xs ${jahresvergleich ? 'text-accent' : ''}`}
+              title="Jahresvergleich"
+            >
+              <ArrowLeftRight className="w-4 h-4" />
+            </button>
+            <button
+              onClick={() => exportCSV(filteredWerte, dataMode, vertraege)}
+              className="ht-btn-ghost text-xs"
+              title="CSV exportieren"
+            >
+              <Download className="w-4 h-4" />
+            </button>
+            <button
               onClick={() => setDataMode((d) => (d === 'verbrauch' ? 'kosten' : 'verbrauch'))}
               className={`ht-btn-ghost text-xs ${dataMode === 'kosten' ? 'text-accent' : ''}`}
             >
@@ -168,117 +190,134 @@ export default function AuswertungenPage() {
       </header>
 
       <main className="max-w-3xl mx-auto px-4 pt-4 space-y-4">
-        <div className="ht-card">
-          <p className="ht-section-title">Zeitraum</p>
-          <div className="flex gap-2 flex-wrap mb-4">
-            {ZEITRAEUME.map((z, i) => (
+        {jahresvergleich && (
+          <div className="ht-card">
+            <p className="ht-section-title">Jahresvergleich</p>
+            <p className="text-xs text-tx-muted">{currentYear - 1} vs. {currentYear} — monatlich aggregiert</p>
+          </div>
+        )}
+
+        {!jahresvergleich && (
+          <div className="ht-card">
+            <p className="ht-section-title">Zeitraum</p>
+            <div className="flex gap-2 flex-wrap mb-4">
+              {ZEITRAEUME.map((z, i) => (
+                <button
+                  key={i}
+                  onClick={() => setZeitraumIdx(i)}
+                  className={`ht-badge cursor-pointer border transition-all duration-150
+                    ${zeitraumIdx === i
+                      ? 'bg-accent/10 border-accent/40 text-accent'
+                      : 'bg-bg-base border-bg-border text-tx-secondary hover:border-accent/30'
+                    }`}
+                >
+                  {z.label}
+                </button>
+              ))}
               <button
-                key={i}
-                onClick={() => setZeitraumIdx(i)}
+                onClick={() => setZeitraumIdx(CUSTOM_IDX)}
                 className={`ht-badge cursor-pointer border transition-all duration-150
-                  ${zeitraumIdx === i
+                  ${zeitraumIdx === CUSTOM_IDX
                     ? 'bg-accent/10 border-accent/40 text-accent'
                     : 'bg-bg-base border-bg-border text-tx-secondary hover:border-accent/30'
                   }`}
               >
-                {z.label}
+                Eigener Zeitraum
               </button>
-            ))}
-            <button
-              onClick={() => setZeitraumIdx(CUSTOM_IDX)}
-              className={`ht-badge cursor-pointer border transition-all duration-150
-                ${zeitraumIdx === CUSTOM_IDX
-                  ? 'bg-accent/10 border-accent/40 text-accent'
-                  : 'bg-bg-base border-bg-border text-tx-secondary hover:border-accent/30'
-                }`}
-            >
-              Eigener Zeitraum
-            </button>
-          </div>
-
-          {zeitraumIdx === CUSTOM_IDX && (
-            <div className="flex gap-3 mb-4">
-              <div className="flex-1">
-                <label className="ht-label">Von</label>
-                <DateInput value={customVon} onChange={setCustomVon} max={customBis} />
-              </div>
-              <div className="flex-1">
-                <label className="ht-label">Bis</label>
-                <DateInput value={customBis} onChange={setCustomBis} min={customVon} max={format(now, 'yyyy-MM-dd')} />
-              </div>
             </div>
-          )}
 
-          {verbrauchstypen.length > 0 && (
-            <>
-              <p className="ht-section-title">Verbrauchstypen</p>
-              <div className="flex gap-2 flex-wrap">
-                {verbrauchstypen.map((typ) => {
-                  const active = activeTypen.includes(typ.id);
-                  return (
-                    <button
-                      key={typ.id}
-                      onClick={() => toggleTyp(typ.id)}
-                      className={`ht-badge cursor-pointer border transition-all duration-150
-                        ${active
-                          ? 'bg-accent/10 border-accent/40 text-accent'
-                          : 'bg-bg-base border-bg-border text-tx-secondary hover:border-accent/30'
-                        }`}
-                    >
-                      {typ.symbol} {typ.name}
-                    </button>
-                  );
-                })}
-              </div>
-
-              {/* Stellenfilter – für alle aktiven Typen mit mindestens einer Stelle */}
-              {typenMitStellen.length > 0 && (
-                <div className="mt-4 pt-3 border-t border-bg-border/50">
-                  <p className="ht-section-title mb-2">Verbrauchsstellen</p>
-                  <div className="space-y-2">
-                    {activeTypen.map(typId => {
-                      const typ = verbrauchstypen.find(t => t.id === typId);
-                      const stellen = typ?.verbrauchsstellen ?? [];
-                      if (stellen.length === 0) return null;
-                      return (
-                        <div key={typId} className="flex items-start gap-3">
-                          <span className="text-[11px] text-tx-muted shrink-0 pt-1 w-20 truncate">
-                            {typ?.symbol} {typ?.name}
-                          </span>
-                          <div className="flex gap-1.5 flex-wrap">
-                            {stellen.map(stelle => {
-                              const selected = (selectedStellen[typId] ?? []).includes(stelle.id);
-                              return (
-                                <button
-                                  key={stelle.id}
-                                  onClick={() => toggleStelle(typId, stelle.id)}
-                                  className={`ht-badge cursor-pointer border transition-all duration-150 text-[11px]
-                                    ${selected
-                                      ? 'bg-accent/10 border-accent/40 text-accent'
-                                      : 'bg-bg-base border-bg-border text-tx-muted hover:border-accent/30'
-                                    }`}
-                                >
-                                  {stelle.bezeichnung}
-                                  {stelle.ist_standard && <span className="ml-1 opacity-50">★</span>}
-                                </button>
-                              );
-                            })}
-                          </div>
-                        </div>
-                      );
-                    })}
-                  </div>
+            {zeitraumIdx === CUSTOM_IDX && (
+              <div className="flex gap-3 mb-4">
+                <div className="flex-1">
+                  <label className="ht-label">Von</label>
+                  <DateInput value={customVon} onChange={setCustomVon} max={customBis} />
                 </div>
-              )}
-            </>
-          )}
-        </div>
+                <div className="flex-1">
+                  <label className="ht-label">Bis</label>
+                  <DateInput value={customBis} onChange={setCustomBis} min={customVon} max={format(now, 'yyyy-MM-dd')} />
+                </div>
+              </div>
+            )}
+          </div>
+        )}
+
+        {verbrauchstypen.length > 0 && (
+          <div className="ht-card">
+            <p className="ht-section-title">Verbrauchstypen</p>
+            <div className="flex gap-2 flex-wrap">
+              {verbrauchstypen.map((typ) => {
+                const active = activeTypen.includes(typ.id);
+                return (
+                  <button
+                    key={typ.id}
+                    onClick={() => toggleTyp(typ.id)}
+                    className={`ht-badge cursor-pointer border transition-all duration-150
+                      ${active
+                        ? 'bg-accent/10 border-accent/40 text-accent'
+                        : 'bg-bg-base border-bg-border text-tx-secondary hover:border-accent/30'
+                      }`}
+                  >
+                    {typ.symbol} {typ.name}
+                  </button>
+                );
+              })}
+            </div>
+
+            {/* Stellenfilter – für alle aktiven Typen mit mindestens einer Stelle */}
+            {typenMitStellen.length > 0 && (
+              <div className="mt-4 pt-3 border-t border-bg-border/50">
+                <p className="ht-section-title mb-2">Verbrauchsstellen</p>
+                <div className="space-y-2">
+                  {activeTypen.map(typId => {
+                    const typ = verbrauchstypen.find(t => t.id === typId);
+                    const stellen = typ?.verbrauchsstellen ?? [];
+                    if (stellen.length === 0) return null;
+                    return (
+                      <div key={typId} className="flex items-start gap-3">
+                        <span className="text-[11px] text-tx-muted shrink-0 pt-1 w-20 truncate">
+                          {typ?.symbol} {typ?.name}
+                        </span>
+                        <div className="flex gap-1.5 flex-wrap">
+                          {stellen.map(stelle => {
+                            const selected = (selectedStellen[typId] ?? []).includes(stelle.id);
+                            return (
+                              <button
+                                key={stelle.id}
+                                onClick={() => toggleStelle(typId, stelle.id)}
+                                className={`ht-badge cursor-pointer border transition-all duration-150 text-[11px]
+                                  ${selected
+                                    ? 'bg-accent/10 border-accent/40 text-accent'
+                                    : 'bg-bg-base border-bg-border text-tx-muted hover:border-accent/30'
+                                  }`}
+                              >
+                                {stelle.bezeichnung}
+                                {stelle.ist_standard && <span className="ml-1 opacity-50">★</span>}
+                              </button>
+                            );
+                          })}
+                        </div>
+                      </div>
+                    );
+                  })}
+                </div>
+              </div>
+            )}
+          </div>
+        )}
 
         <GraphQLErrorBoundary onRetry={refetch}>
           {loading ? (
             <div className="flex items-center justify-center py-20">
               <Loader2 className="w-6 h-6 text-accent animate-spin" />
             </div>
+          ) : jahresvergleich ? (
+            jvData.length === 0 ? (
+              <div className="ht-card text-center py-12">
+                <p className="text-tx-muted text-sm">Keine Daten für den Jahresvergleich.</p>
+              </div>
+            ) : (
+              <JahresvergleichChart data={jvData} verbrauchstypen={verbrauchstypen} activeTypen={activeTypen} currentYear={currentYear} dataMode={dataMode} />
+            )
           ) : chartData.length === 0 ? (
             <div className="ht-card text-center py-12">
               <p className="text-tx-muted text-sm">Keine Daten für den gewählten Zeitraum.</p>
@@ -442,6 +481,40 @@ function berechneKosten(datum: string, typId: string, verbrauch: number, vertrae
   return verbrauch * periode.einheitspreis * steuer;
 }
 
+function exportCSV(werte: Verbrauchswert[], dataMode: DataMode, vertraege: any[]) {
+  const sep = ';';
+  const num = (v: number, digits = 2) => v.toFixed(digits).replace('.', ',');
+
+  const headers = dataMode === 'kosten'
+    ? ['Datum', 'Typ', 'Stelle', 'Zählerstand', 'Verbrauch', 'Einheit', 'Kosten (€)']
+    : ['Datum', 'Typ', 'Stelle', 'Zählerstand', 'Verbrauch', 'Einheit'];
+
+  const rows = werte.map(w => {
+    const kosten = dataMode === 'kosten' && w.verbrauch != null
+      ? berechneKosten(w.datum, w.verbrauchstyp?.id ?? '', w.verbrauch, vertraege)
+      : null;
+    const base = [
+      format(new Date(w.datum), 'dd.MM.yyyy'),
+      w.verbrauchstyp?.name ?? '',
+      w.verbrauchsstelle?.bezeichnung ?? '',
+      num(Number(w.zaehlerstand), 3),
+      w.verbrauch != null ? num(Number(w.verbrauch), 3) : '',
+      w.verbrauchstyp?.einheit ?? '',
+    ];
+    if (dataMode === 'kosten') base.push(kosten != null ? num(kosten) : '');
+    return base.join(sep);
+  });
+
+  const csv = '\uFEFF' + [headers.join(sep), ...rows].join('\n');
+  const blob = new Blob([csv], { type: 'text/csv;charset=utf-8;' });
+  const url = URL.createObjectURL(blob);
+  const a = document.createElement('a');
+  a.href = url;
+  a.download = `hometrack-export-${format(new Date(), 'yyyy-MM-dd')}.csv`;
+  a.click();
+  URL.revokeObjectURL(url);
+}
+
 function buildChartData(verbrauchswerte: Verbrauchswert[], typen: Verbrauchstyp[], dataMode: DataMode, vertraege: any[]): ChartDataPoint[] {
   if (!verbrauchswerte.length) return [];
 
@@ -483,4 +556,113 @@ function buildChartData(verbrauchswerte: Verbrauchswert[], typen: Verbrauchstyp[
   return Object.entries(byDate)
     .sort(([a], [b]) => a.localeCompare(b))
     .map(([, point]) => point);
+}
+
+const MONATSNAMEN = ['Jan', 'Feb', 'Mär', 'Apr', 'Mai', 'Jun', 'Jul', 'Aug', 'Sep', 'Okt', 'Nov', 'Dez'];
+
+function buildJahresvergleichData(
+  werte: Verbrauchswert[],
+  typen: Verbrauchstyp[],
+  activeTypen: string[],
+  dataMode: DataMode,
+  vertraege: any[],
+  currentYear: number,
+): ChartDataPoint[] {
+  const prevYear = currentYear - 1;
+  // Bucket: { [monat 0-11]: { [key like "Strom 2026"]: number } }
+  const buckets: Record<number, Record<string, number>> = {};
+  for (let m = 0; m < 12; m++) buckets[m] = {};
+
+  for (const w of werte) {
+    const typId = w.verbrauchstyp?.id;
+    const typName = w.verbrauchstyp?.name;
+    if (!typId || !typName || !activeTypen.includes(typId)) continue;
+
+    const d = new Date(w.datum);
+    const year = d.getFullYear();
+    if (year !== currentYear && year !== prevYear) continue;
+
+    const month = d.getMonth();
+    const verbrauch = w.verbrauch ?? 0;
+
+    let value: number;
+    if (dataMode === 'kosten') {
+      value = berechneKosten(w.datum, typId, verbrauch, vertraege) ?? 0;
+    } else {
+      value = verbrauch;
+    }
+
+    const key = `${typName} ${year}`;
+    buckets[month][key] = (buckets[month][key] ?? 0) + value;
+  }
+
+  return Array.from({ length: 12 }, (_, m) => ({
+    datum: MONATSNAMEN[m],
+    ...buckets[m],
+  }));
+}
+
+interface JVChartProps {
+  data: ChartDataPoint[];
+  verbrauchstypen: Verbrauchstyp[];
+  activeTypen: string[];
+  currentYear: number;
+  dataMode: DataMode;
+}
+
+function JahresvergleichChart({ data, verbrauchstypen, activeTypen, currentYear, dataMode }: JVChartProps) {
+  const prevYear = currentYear - 1;
+  const activeTypes = verbrauchstypen.filter(t => activeTypen.includes(t.id));
+
+  return (
+    <div className="ht-card animate-fade-in">
+      <p className="ht-section-title">{dataMode === 'kosten' ? 'Kostenvergleich (€)' : 'Verbrauchsvergleich'} — {prevYear} vs. {currentYear}</p>
+      <ResponsiveContainer width="100%" height={300}>
+        <LineChart data={data} margin={{ top: 5, right: 5, bottom: 5, left: 0 }}>
+          <CartesianGrid strokeDasharray="3 3" stroke="#243044" vertical={false} />
+          <XAxis dataKey="datum" tick={{ fill: '#8b9ab5', fontSize: 11 }} axisLine={false} tickLine={false} />
+          <YAxis tick={{ fill: '#8b9ab5', fontSize: 11 }} axisLine={false} tickLine={false} width={50} />
+          <Tooltip
+            contentStyle={{
+              backgroundColor: '#1a2232',
+              border: '1px solid #243044',
+              borderRadius: '8px',
+              color: '#e8edf5',
+              fontSize: '12px',
+            }}
+            formatter={(value: number, name: string) => {
+              const formatted = Number(value).toLocaleString('de-DE', { maximumFractionDigits: 2 });
+              return dataMode === 'kosten' ? [`${formatted} €`, name] : [formatted, name];
+            }}
+          />
+          <Legend wrapperStyle={{ fontSize: '12px', color: '#8b9ab5', paddingTop: '12px' }} />
+          {activeTypes.map(typ => {
+            const color = typ.farbe || '#f97316';
+            return [
+              <Line
+                key={`${typ.id}-curr`}
+                type="monotone"
+                dataKey={`${typ.name} ${currentYear}`}
+                stroke={color}
+                strokeWidth={2}
+                dot={{ r: 3, fill: color }}
+                activeDot={{ r: 5 }}
+              />,
+              <Line
+                key={`${typ.id}-prev`}
+                type="monotone"
+                dataKey={`${typ.name} ${prevYear}`}
+                stroke={color}
+                strokeWidth={1.5}
+                strokeDasharray="5 5"
+                strokeOpacity={0.5}
+                dot={{ r: 2, fill: color, fillOpacity: 0.5 }}
+                activeDot={{ r: 4 }}
+              />,
+            ];
+          })}
+        </LineChart>
+      </ResponsiveContainer>
+    </div>
+  );
 }

--- a/src/app/einstellungen/page.tsx
+++ b/src/app/einstellungen/page.tsx
@@ -8,7 +8,7 @@ import { Plus, Trash2, Edit3, ChevronDown, ChevronUp, Loader2, LogOut, Star, Ref
 import Navigation from '@/components/layout/Navigation';
 import { usePlusAction } from '@/lib/plus-action-context';
 import { GET_VERBRAUCHSTYPEN, GET_ANBIETER, GET_VERTRAEGE, GET_VERBRAUCHSWERTE_FOR_RECALC, GET_USER_SETTINGS } from '@/lib/graphql/queries';
-import { DELETE_VERBRAUCHSTYP, DELETE_ANBIETER, DELETE_VERTRAG, SET_STANDARD_STELLE, DELETE_VERBRAUCHSSTELLE, UPDATE_VERBRAUCHSWERT, UPSERT_USER_SETTINGS, UPDATE_USER_PROFILE } from '@/lib/graphql/mutations';
+import { DELETE_VERBRAUCHSTYP, DELETE_ANBIETER, DELETE_VERTRAG, DELETE_PREISPERIODE, SET_STANDARD_STELLE, DELETE_VERBRAUCHSSTELLE, UPDATE_VERBRAUCHSWERT, UPSERT_USER_SETTINGS, UPDATE_USER_PROFILE } from '@/lib/graphql/mutations';
 import VerbrauchstypModal from '@/components/modals/VerbrauchstypModal';
 import VerbrauchsstellenModal from '@/components/modals/VerbrauchsstellenModal';
 import AnbieterModal from '@/components/modals/AnbieterModal';
@@ -288,7 +288,9 @@ function AnbieterTab({ showCreate, onCreateClose }: { showCreate: boolean; onCre
 function VertraegeTab({ showCreate, onCreateClose }: { showCreate: boolean; onCreateClose: () => void }) {
   const { data, loading, refetch } = useQuery(GET_VERTRAEGE);
   const [deleteVertrag] = useMutation(DELETE_VERTRAG, { onCompleted: () => refetch() });
+  const [deletePreis] = useMutation(DELETE_PREISPERIODE, { onCompleted: () => refetch() });
   const [editItem, setEditItem] = useState<any | null>(null);
+  const [editPreis, setEditPreis] = useState<any | null>(null);
   const [expanded, setExpanded] = useState<string | null>(null);
   const [showPreis, setShowPreis] = useState<string | null>(null);
 
@@ -351,14 +353,22 @@ function VertraegeTab({ showCreate, onCreateClose }: { showCreate: boolean; onCr
                 </div>
                 {v.preisperioden?.map((p: any) => (
                   <div key={p.id} className="bg-bg-base/60 rounded-lg px-3 py-2 mb-1.5 text-xs">
-                    <div className="flex justify-between">
-                      <span className="text-tx-muted">ab {p.gueltig_ab}</span>
-                      {p.gueltig_bis && <span className="text-tx-muted">bis {p.gueltig_bis}</span>}
-                    </div>
-                    <div className="flex gap-4 mt-1">
-                      <span className="text-tx-secondary">GP: <span className="font-mono text-tx-primary">{Number(p.grundpreis).toFixed(2)} €/{p.grundpreis_intervall || 'Mon.'}</span></span>
-                      <span className="text-tx-secondary">AP: <span className="font-mono text-tx-primary">{Number(p.einheitspreis).toFixed(4)} €</span></span>
-                      {p.steuer && <span className="text-tx-muted">MwSt: {p.steuer}%</span>}
+                    <div className="flex justify-between items-start">
+                      <div className="flex-1">
+                        <div className="flex justify-between">
+                          <span className="text-tx-muted">ab {p.gueltig_ab}</span>
+                          {p.gueltig_bis && <span className="text-tx-muted">bis {p.gueltig_bis}</span>}
+                        </div>
+                        <div className="flex gap-4 mt-1">
+                          <span className="text-tx-secondary">GP: <span className="font-mono text-tx-primary">{Number(p.grundpreis).toFixed(2)} €/{p.grundpreis_intervall || 'Mon.'}</span></span>
+                          <span className="text-tx-secondary">AP: <span className="font-mono text-tx-primary">{Number(p.einheitspreis).toFixed(4)} €</span></span>
+                          {p.steuer && <span className="text-tx-muted">MwSt: {p.steuer}%</span>}
+                        </div>
+                      </div>
+                      <div className="flex items-center gap-0.5 ml-2 flex-shrink-0">
+                        <button onClick={() => setEditPreis({ ...p, vertrag_id: v.id })} className="ht-btn-ghost p-1"><Edit3 className="w-3 h-3" /></button>
+                        <button onClick={() => deletePreis({ variables: { id: p.id } })} className="ht-btn-ghost p-1 text-red-400/70 hover:text-red-400"><Trash2 className="w-3 h-3" /></button>
+                      </div>
                     </div>
                   </div>
                 ))}
@@ -377,10 +387,11 @@ function VertraegeTab({ showCreate, onCreateClose }: { showCreate: boolean; onCr
           onClose={() => { onCreateClose(); setEditItem(null); refetch(); }}
         />
       )}
-      {showPreis && (
+      {(showPreis || editPreis) && (
         <PreisperiodeModal
-          vertragId={showPreis}
-          onClose={() => { setShowPreis(null); refetch(); }}
+          vertragId={showPreis || editPreis?.vertrag_id}
+          editData={editPreis}
+          onClose={() => { setShowPreis(null); setEditPreis(null); refetch(); }}
         />
       )}
     </div>

--- a/src/components/home/VerbrauchsDetailDrawer.tsx
+++ b/src/components/home/VerbrauchsDetailDrawer.tsx
@@ -8,6 +8,7 @@ import { X, Plus, Edit3, Trash2, Loader2, FileText, Image } from 'lucide-react';
 import { GET_VERBRAUCHSWERTE_LIST } from '@/lib/graphql/queries';
 import { DELETE_VERBRAUCHSWERT } from '@/lib/graphql/mutations';
 import VerbrauchswertModal from '@/components/modals/VerbrauchswertModal';
+import StorageImage from '@/components/ui/StorageImage';
 import { Verbrauchstyp, Verbrauchswert } from '@/types';
 
 interface Props {
@@ -31,6 +32,7 @@ export default function VerbrauchsDetailDrawer({ verbrauchstyp, onClose }: Props
   const [editItem, setEditItem]     = useState<Verbrauchswert | null>(null);
   const [deleteConfirm, setDeleteConfirm] = useState<string | null>(null);
   const [filterStelle, setFilterStelle]   = useState<string | null>(null);
+  const [lightboxUrl, setLightboxUrl]     = useState<string | null>(null);
 
   const werte: Verbrauchswert[] = data?.verbrauchswert ?? [];
 
@@ -201,9 +203,12 @@ export default function VerbrauchsDetailDrawer({ verbrauchstyp, onClose }: Props
                           </span>
                         )}
                         {wert.bild_url && (
-                          <span className="text-tx-muted/60">
+                          <button
+                            onClick={() => setLightboxUrl(wert.bild_url!)}
+                            className="text-tx-muted/60 hover:text-accent transition-colors"
+                          >
                             <Image className="w-2.5 h-2.5" />
-                          </span>
+                          </button>
                         )}
                       </div>
                     )}
@@ -238,6 +243,26 @@ export default function VerbrauchsDetailDrawer({ verbrauchstyp, onClose }: Props
           editData={editItem ?? undefined}
           onClose={handleModalClose}
         />
+      )}
+
+      {/* Foto-Lightbox */}
+      {lightboxUrl && (
+        <div
+          className="fixed inset-0 z-[60] bg-black/90 backdrop-blur-sm flex items-center justify-center animate-fade-in"
+          onClick={() => setLightboxUrl(null)}
+        >
+          <button
+            onClick={() => setLightboxUrl(null)}
+            className="absolute top-4 right-4 ht-btn-ghost p-2 text-white/70 hover:text-white z-10"
+          >
+            <X className="w-6 h-6" />
+          </button>
+          <StorageImage
+            src={lightboxUrl}
+            alt="Zählerstandsfoto"
+            className="max-w-[90vw] max-h-[85vh] object-contain rounded-lg"
+          />
+        </div>
       )}
     </>
   );

--- a/src/components/modals/PreisperiodeModal.tsx
+++ b/src/components/modals/PreisperiodeModal.tsx
@@ -5,7 +5,7 @@ import { useMutation } from '@apollo/client';
 import { Loader2 } from 'lucide-react';
 import Modal from './Modal';
 import DateInput from '@/components/ui/DateInput';
-import { INSERT_PREISPERIODE } from '@/lib/graphql/mutations';
+import { INSERT_PREISPERIODE, UPDATE_PREISPERIODE } from '@/lib/graphql/mutations';
 import { GET_VERTRAEGE } from '@/lib/graphql/queries';
 
 interface Props {
@@ -15,39 +15,43 @@ interface Props {
 }
 
 export default function PreisperiodeModal({ vertragId, editData, onClose }: Props) {
+  const isEdit = !!editData?.id;
+
   const [form, setForm] = useState({
     gueltig_ab:           editData?.gueltig_ab           || new Date().toISOString().split('T')[0],
     gueltig_bis:          editData?.gueltig_bis          || '',
-    grundpreis:           editData?.grundpreis           || '',
+    grundpreis:           editData?.grundpreis != null ? String(editData.grundpreis) : '',
     grundpreis_intervall: editData?.grundpreis_intervall || 'monatlich',
-    einheitspreis:        editData?.einheitspreis        || '',
-    steuer:               editData?.steuer               || '19',
+    einheitspreis:        editData?.einheitspreis != null ? String(editData.einheitspreis) : '',
+    steuer:               editData?.steuer != null ? String(editData.steuer) : '19',
     notizen:              editData?.notizen              || '',
   });
 
-  const [insertPreis, { loading }] = useMutation(INSERT_PREISPERIODE, {
-    refetchQueries: [{ query: GET_VERTRAEGE }],
-    onCompleted: onClose,
-  });
+  const refetchOpts = { refetchQueries: [{ query: GET_VERTRAEGE }], onCompleted: onClose };
+  const [insertPreis, { loading: inserting }] = useMutation(INSERT_PREISPERIODE, refetchOpts);
+  const [updatePreis, { loading: updating }] = useMutation(UPDATE_PREISPERIODE, refetchOpts);
+  const loading = inserting || updating;
 
   const handleSubmit = (e: React.FormEvent) => {
     e.preventDefault();
-    insertPreis({
-      variables: {
-        obj: {
-          ...form,
-          vertrag_id:    vertragId,
-          gueltig_bis:   form.gueltig_bis   || null,
-          grundpreis:    parseFloat(form.grundpreis as any)    || 0,
-          einheitspreis: parseFloat(form.einheitspreis as any) || 0,
-          steuer:        parseFloat(form.steuer as any)        || 19,
-        },
-      },
-    });
+    const clean = {
+      gueltig_ab:           form.gueltig_ab,
+      gueltig_bis:          form.gueltig_bis || null,
+      grundpreis:           parseFloat(form.grundpreis as any) || 0,
+      grundpreis_intervall: form.grundpreis_intervall,
+      einheitspreis:        parseFloat(form.einheitspreis as any) || 0,
+      steuer:               parseFloat(form.steuer as any) || 19,
+      notizen:              form.notizen || null,
+    };
+    if (isEdit) {
+      updatePreis({ variables: { id: editData.id, set: clean } });
+    } else {
+      insertPreis({ variables: { obj: { ...clean, vertrag_id: vertragId } } });
+    }
   };
 
   return (
-    <Modal title="Preisperiode hinzufügen" onClose={onClose}>
+    <Modal title={isEdit ? 'Preisperiode bearbeiten' : 'Preisperiode hinzufügen'} onClose={onClose}>
       <form onSubmit={handleSubmit} className="space-y-4">
         <div className="grid grid-cols-2 gap-3">
           <div>
@@ -93,7 +97,7 @@ export default function PreisperiodeModal({ vertragId, editData, onClose }: Prop
         <div className="flex gap-3 pt-2">
           <button type="button" onClick={onClose} className="ht-btn-secondary flex-1 justify-center">Abbrechen</button>
           <button type="submit" disabled={loading} className="ht-btn-primary flex-1 justify-center">
-            {loading ? <Loader2 className="w-4 h-4 animate-spin" /> : 'Hinzufügen'}
+            {loading ? <Loader2 className="w-4 h-4 animate-spin" /> : isEdit ? 'Speichern' : 'Hinzufügen'}
           </button>
         </div>
       </form>


### PR DESCRIPTION
## Summary

- **Preisperioden Edit/Delete** (#30): PreisperiodeModal um Edit-Modus erweitert (UPDATE_PREISPERIODE), Edit3/Trash2-Buttons an Preisperioden-Karten in Einstellungen, DELETE_PREISPERIODE eingebunden
- **CSV-Export** (#32): Download-Button im Auswertungen-Header, `exportCSV()` mit Semicolon-Separator (deutsche Excel-Kompatibilität), Komma als Dezimaltrenner, UTF-8 BOM für korrekte Umlaute, übernimmt aktive Filter (Zeitraum, Typ, Stelle, Modus)
- **Foto-Lightbox** (#32): Image-Icon im VerbrauchsDetailDrawer ist jetzt ein Button, öffnet Fullscreen-Overlay mit StorageImage (`z-[60]` über Drawer), X-Button und Backdrop-Click zum Schließen
- **Jahresvergleich** (#33): ArrowLeftRight-Toggle in Auswertungen, lädt automatisch 2 Jahre Daten, monatliche Aggregation, LineChart mit solid (aktuelles Jahr) vs. gestrichelt (Vorjahr), Typfilter bleiben nutzbar, Zeitraum-Karte wird ausgeblendet

## Geänderte Dateien
- `src/components/modals/PreisperiodeModal.tsx` — Edit-Modus, dynamischer Titel/Button
- `src/app/einstellungen/page.tsx` — Edit/Delete-Buttons für Preisperioden, DELETE_PREISPERIODE Import
- `src/app/auswertungen/page.tsx` — CSV-Export, Jahresvergleich (Toggle, buildJahresvergleichData, JahresvergleichChart)
- `src/components/home/VerbrauchsDetailDrawer.tsx` — Foto-Lightbox mit StorageImage

## Test plan
- [ ] Einstellungen → Verträge → Vertrag aufklappen → Preisperiode bearbeiten (Edit-Icon) → Werte ändern → Speichern
- [ ] Einstellungen → Verträge → Preisperiode löschen (Trash-Icon) → Karte verschwindet
- [ ] Auswertungen → Download-Button klicken → CSV öffnen in Excel → Semicolon-Trennung, Umlaute, Zahlenformat prüfen
- [ ] Auswertungen → Kostenmodus aktivieren → CSV erneut exportieren → Kostenspalte vorhanden
- [ ] Dashboard → Verbrauchstyp öffnen → Eintrag mit Foto-Icon → Icon klicken → Fullscreen-Overlay mit Bild
- [ ] Lightbox → X-Button oder Backdrop klicken → Overlay schließt
- [ ] Auswertungen → Jahresvergleich-Toggle (⇄) aktivieren → LineChart zeigt Monate Jan–Dez
- [ ] Jahresvergleich → Aktuelles Jahr solid, Vorjahr gestrichelt → Tooltip zeigt beide Werte
- [ ] Jahresvergleich → Typfilter funktioniert weiterhin
- [ ] Jahresvergleich → Toggle deaktivieren → normale Ansicht kehrt zurück

🤖 Generated with [Claude Code](https://claude.com/claude-code)